### PR TITLE
Handle empty ring after node removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -40,6 +46,11 @@
                     <target>${java.version}</target>
                     <parameters>true</parameters>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/consistenthashing/node/ConsistentHashRing.java
+++ b/src/main/java/com/example/consistenthashing/node/ConsistentHashRing.java
@@ -62,14 +62,21 @@ public class ConsistentHashRing {
             if (!nodeMap.containsKey(nodeId)) {
                 return;
             }
-            List<String> keys = nodeMap.get(nodeId)
-                    .getKeys();
+            Node removedNode = nodeMap.get(nodeId);
+            List<String> keys = removedNode.getKeys();
             nodeMap.remove(nodeId);
             ring.values().removeIf(nodeId::equals);
+
+            if (ring.isEmpty()) {
+                keys.clear();
+                return;
+            }
+
             for (String key : keys) {
                 Node nodeForKey = getNodeForKey(key);
                 nodeForKey.getKeys().add(key);
             }
+            keys.clear();
         } finally {
             lock.writeLock().unlock();
         }

--- a/src/test/java/com/example/consistenthashing/node/ConsistentHashRingTest.java
+++ b/src/test/java/com/example/consistenthashing/node/ConsistentHashRingTest.java
@@ -1,0 +1,36 @@
+package com.example.consistenthashing.node;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConsistentHashRingTest {
+
+    @Test
+    void removeLastNodeWhenSingleNodePresent() {
+        ConsistentHashRing ring = new ConsistentHashRing(5);
+        ring.addNode("node1");
+        Node node = ring.getNodeForKey("k1");
+        node.getKeys().add("k1");
+
+        assertDoesNotThrow(() -> ring.removeNode("node1"));
+        assertTrue(node.getKeys().isEmpty());
+    }
+
+    @Test
+    void removeLastNodeAfterSequentialRemovals() {
+        ConsistentHashRing ring = new ConsistentHashRing(5);
+        ring.addNode("node1");
+        ring.addNode("node2");
+
+        Node nodeWithKey = ring.getNodeForKey("k2");
+        nodeWithKey.getKeys().add("k2");
+
+        String remainingId = nodeWithKey.getId();
+        String firstRemoveId = remainingId.equals("node1") ? "node2" : "node1";
+
+        ring.removeNode(firstRemoveId);
+        assertDoesNotThrow(() -> ring.removeNode(remainingId));
+        assertTrue(nodeWithKey.getKeys().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- avoid assigning keys when removing the last node
- add JUnit to the build
- add tests to verify node removal when ring becomes empty